### PR TITLE
feat: add Export/Download ZIP feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "fflate": "^0.8.2",
         "jose": "^6.0.11",
         "lucide-react": "^0.517.0",
         "next": "^15.5.12",
@@ -6192,6 +6193,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fflate": "^0.8.2",
     "jose": "^6.0.11",
     "lucide-react": "^0.517.0",
     "next": "^15.5.12",

--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Plus, LogOut, FolderOpen, ChevronDown } from "lucide-react";
+import { Plus, LogOut, FolderOpen, ChevronDown, Download } from "lucide-react";
 import { AuthDialog } from "@/components/auth/AuthDialog";
 import { signOut } from "@/actions";
 import { getProjects } from "@/actions/get-projects";
@@ -21,6 +21,8 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { useFileSystem } from "@/lib/contexts/file-system-context";
+import { downloadProjectZip } from "@/lib/download-zip";
 
 interface HeaderActionsProps {
   user?: {
@@ -39,6 +41,7 @@ interface Project {
 
 export function HeaderActions({ user, projectId }: HeaderActionsProps) {
   const router = useRouter();
+  const { getAllFiles } = useFileSystem();
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const [authMode, setAuthMode] = useState<"signin" | "signup">("signin");
   const [projectsOpen, setProjectsOpen] = useState(false);
@@ -81,6 +84,12 @@ export function HeaderActions({ user, projectId }: HeaderActionsProps) {
 
   const handleSignOut = async () => {
     await signOut();
+  };
+
+  const handleDownload = () => {
+    const files = getAllFiles();
+    const name = currentProject?.name ?? "uigen-project";
+    downloadProjectZip(files, name);
   };
 
   const handleNewDesign = async () => {
@@ -159,6 +168,18 @@ export function HeaderActions({ user, projectId }: HeaderActionsProps) {
         <Plus className="h-4 w-4" />
         New Design
       </Button>
+
+      {projectId && (
+        <Button
+          variant="outline"
+          className="flex items-center gap-2 h-8"
+          onClick={handleDownload}
+          title="Download project as ZIP"
+        >
+          <Download className="h-4 w-4" />
+          Download
+        </Button>
+      )}
 
       <Button
         variant="ghost"

--- a/src/lib/download-zip.ts
+++ b/src/lib/download-zip.ts
@@ -1,0 +1,30 @@
+import { zipSync, strToU8 } from "fflate";
+
+/**
+ * Packages all files from the virtual file system into a ZIP archive
+ * and triggers a browser download.
+ */
+export function downloadProjectZip(
+  files: Map<string, string>,
+  projectName: string = "uigen-project"
+) {
+  if (files.size === 0) return;
+
+  // Build the fflate zip input: strip leading slash from paths
+  const zipInput: Record<string, Uint8Array> = {};
+  for (const [path, content] of files) {
+    const relativePath = path.startsWith("/") ? path.slice(1) : path;
+    zipInput[relativePath] = strToU8(content);
+  }
+
+  const zipped = zipSync(zipInput);
+  const blob = new Blob([zipped], { type: "application/zip" });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${projectName}.zip`;
+  anchor.click();
+
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

- Add a **Download** button to the header toolbar that packages all virtual file system files into a ZIP archive and triggers a browser download
- New utility `src/lib/download-zip.ts` uses [fflate](https://github.com/101arrowz/fflate) for lightweight, browser-compatible ZIP generation
- Button is only shown when a project is open (`projectId` is set)
- ZIP filename defaults to the project name (e.g., `Design #12345.zip`)

## Test plan

- [ ] Open a project and generate a component via chat
- [ ] Click the **Download** button in the top-right toolbar
- [ ] Verify a `.zip` file is downloaded with the project name
- [ ] Extract the ZIP and confirm all generated files are present with correct content
- [ ] Verify the button is hidden on the Sign In / Sign Up view (no project open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)